### PR TITLE
Bump node-version from 18 to 25

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 25
       - name: Install dependencies
         run: npm ci
       - name: Build the project


### PR DESCRIPTION
Fix wrong node.js version for GitHub Action workflow.