### PR TITLE
Cypress fine - tuning

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "cypress";
 
 export default defineConfig({
+  allowCypressEnv: false,
   e2e: {
     baseUrl: 'http://localhost:3000',
   },


### PR DESCRIPTION
Disable allowCypressEnv to silence cypress deprecation warning during runner actions.