### PR TITLE
Fix listener leak and any typing in useDots

### DIFF
--- a/pages/components/dots.tsx
+++ b/pages/components/dots.tsx
@@ -2,20 +2,26 @@ import { useEffect } from 'react'
 
 function useDots() {
 	useEffect(() => {
-		let menuEl: any
-		menuEl = document.querySelector('.menu')
-		const menuItems = document.querySelectorAll('.menu-item')
+		const menuEl = document.querySelector<HTMLElement>('.menu')
+		const menuItems = document.querySelectorAll<HTMLElement>('.menu-item')
 
-		const handleMouseOver = index => {
-			menuEl.dataset.activeIndex = index
+		if (!menuEl) return
+
+		const handleMouseOver = (index: number) => {
+			menuEl.dataset.activeIndex = String(index)
 		}
 
-		Array.from(menuItems).forEach((item, index) => {
-			const element = item as HTMLElement
-			element.addEventListener('mouseover', () => {
-				handleMouseOver(index)
-			})
+		const listeners = Array.from(menuItems).map((element, index) => {
+			const listener = () => handleMouseOver(index)
+			element.addEventListener('mouseover', listener)
+			return { element, listener }
 		})
+
+		return () => {
+			listeners.forEach(({ element, listener }) => {
+				element.removeEventListener('mouseover', listener)
+			})
+		}
 	}, [])
 	return
 }


### PR DESCRIPTION
The mouseover listeners useDots attaches to .menu-item elements were never removed, so navigating between pages (or React's dev-mode double-invoke) accumulated duplicate listeners on stale DOM nodes. menuEl was also typed any, hiding that document.querySelector('.menu') can return null.

Adds a cleanup function that removes each listener on unmount, types menuEl as HTMLElement | null with a guard, and drops the any.